### PR TITLE
0.6

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1994,7 +1994,7 @@ int run_save(int argc, char **argv)
 		if (num_pths > 1)
 			fprintf(fp, "%d\n", i + 1);
 		sprintf(buf, "VPCS[%d]", i + 1);
-		if (strncmp(vpc[i].xname, buf, 3))
+		if (strncmp(vpc[i].xname, buf, 6))
 			fprintf(fp, "set pcname %s\n", vpc[i].xname);
 
 		if (num_pths > 1) {

--- a/src/command.c
+++ b/src/command.c
@@ -1994,8 +1994,8 @@ int run_save(int argc, char **argv)
 		if (num_pths > 1)
 			fprintf(fp, "%d\n", i + 1);
 		sprintf(buf, "VPCS[%d]", i + 1);
-		if (strncmp(vpc[i].xname, buf, 6))
-			fprintf(fp, "set pcname %s\n", vpc[i].xname);
+		//if (strncmp(vpc[i].xname, buf, 6))
+		fprintf(fp, "set pcname %s\n", vpc[i].xname);
 
 		if (num_pths > 1) {
 			if (vpc[i].lport != (20000 + i))

--- a/src/dev.c
+++ b/src/dev.c
@@ -170,10 +170,11 @@ int open_tap(int id)
 	
 	if (num_pths > 1)
 		sprintf(dev, "tap%d", id);
-	else
+	else {
 		if (strlen(tapname) >= IFNAMSIZ)
 			return(-1);
 		sprintf(dev, "%s", tapname);
+	}
 
 	if ((fd = open("/dev/net/tun", O_RDWR)) < 0) {
 		return(-1);

--- a/src/relay.c
+++ b/src/relay.c
@@ -83,15 +83,16 @@ int run_relay(int argc, char **argv)
 	}
 	if (argc == 3 && !strcmp(argv[1], "port")) {
 		port = atoi(argv[2]);
-		if (port > 1024 && port < 65534)
+		if (port > 1024 && port < 65534) {
 			relay_port = port;
 			if (relay_fd) {
 				close(relay_fd);
 			
-			relay_fd = open_udp(relay_port);
-			if (relay_fd <= 0) {
-				printf("Open relay port %d error [%s]\n", 
-				    relay_port, strerror(errno));
+				relay_fd = open_udp(relay_port);
+				if (relay_fd <= 0) {
+					printf("Open relay port %d error [%s]\n",
+						relay_port, strerror(errno));
+				}
 			}
 		} else
 			printf("The port is out of range\n");

--- a/src/vpcs.c
+++ b/src/vpcs.c
@@ -148,7 +148,8 @@ int main(int argc, char **argv)
 	int i;
 	char prompt[MAX_LEN];
 	int c;
-	pthread_t timer_pid, relay_pid, bgjob_pid;
+	pthread_t timer_pid, bgjob_pid;
+	// pthread_t relay_pid;
 	int daemon_bg = 1;
 	char *cmd;
 


### PR DESCRIPTION
Hi

We can use VPCS-1 as pcname (change on command.c). The previous code compared only 3 characters with his own default name (VPCS[1])

As gcc shows warnings,  i have also tried to correct them. (misleading indentation). I suppose that is a python developer who has coded this code. I am not sure that it is correct but that seems logical