### PR TITLE
remove -I. from linux Makefile

### DIFF
--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -5,7 +5,7 @@ CPUTYPE=i386
 OPT=-O2
 HVOPT=-DHV
 
-CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(OPT) $(HVOPT) -Wall -I. -DTAP
+CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(OPT) $(HVOPT) -Wall -DTAP
 LDFLAGS=-lpthread -lutil -s -static
 OBJS=vpcs.o \
 	daemon.o \


### PR DESCRIPTION
prevents duplicate getopt declaration since unistd.h includes the system
getopt_posix.h but due to -I. the "local" getopt.h redeclares getopt

gcc    -DLinux -Di386 -O2 -DHV -Wall -I. -DTAP -c hv.c
In file included from hv.c:45:
./getopt.h:53:5: error: conflicting types for ‘getopt’
 int getopt(int argc, char** argv, char* optstr);
     ^~~~~~
In file included from /usr/include/x86_64-linux-gnu/bits/getopt_posix.h:27,
                 from /usr/include/unistd.h:869,
                 from hv.c:33:
/usr/include/x86_64-linux-gnu/bits/getopt_core.h:91:12: note: previous declaration of ‘getopt’ was here
 extern int getopt (int ___argc, char *const *___argv, const char *__shortopts)
            ^~~~~~
make: *** [Makefile.linux:37: hv.o] Error 1