### PR TITLE
fix failure to receive DHCP offer

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -133,7 +133,7 @@ int upv4(pcs *pc, struct packet **m0)
 			char *data = NULL;
 			ui = (udpiphdr *)ip;
 			
-			if (IN_MULTICAST(ip->dip))
+			if (IN_MULTICAST(ntohl(ip->dip)))
 				return PKT_DROP;
 			
 			/* dhcp packet */


### PR DESCRIPTION
This change resolves a bug preventing VPCS from receiving a DHCP offer if the assigned address if the last octet = 0xE0