### PR TITLE
Backport 9019b7fcfa89e5944e6c1ffba4a2e1f53899f4fa "extern" to 0.6 branch

### DIFF
--- a/src/vpcs.c
+++ b/src/vpcs.c
@@ -56,6 +56,8 @@ const char *ver = "0.6.3";
 /* track the binary */
 static const char *ident = "$Id$";
 
+pcs vpc[MAX_NUM_PTHS];
+
 int pcid = 0;  /* current vpc id */
 int devtype = 0;
 int lport = 20000;

--- a/src/vpcs.h
+++ b/src/vpcs.h
@@ -126,7 +126,7 @@ struct echoctl {
 	int bgcolor;
 };
 
-pcs vpc[MAX_NUM_PTHS];
+extern pcs vpc[MAX_NUM_PTHS];
 
 #define delay_ms(s) usleep(s * 1000)
 


### PR DESCRIPTION
See: 9019b7fcfa89e5944e6c1ffba4a2e1f53899f4fa
This is because `gns3-server-2.2.31` wants VPCS 0.6.
I recommend shipping a new VPCS 0.6 release and ideally a corresponding GNS3 source release after merge, assuming you have some tests on your side.
