### PR TITLE
OpenBSD support

### DIFF
--- a/src/Makefile.obsd
+++ b/src/Makefile.obsd
@@ -1,0 +1,51 @@
+RM=rm -f
+CC=clang $(CCOPT)
+OSTYPE=OpenBSD
+CPUTYPE=i386
+OPT=-Wall
+HVOPT=-DHV
+
+#CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(OPT) $(HVOPT) $(DBGOPT) -D_BSD_SOURCE -I.
+CFLAGS=-D$(OSTYPE) -D$(CPUTYPE) $(OPT) $(HVOPT) $(DBGOPT) -I.
+LDFLAGS=-lpthread -lutil -static $(STRIP)
+OBJS=vpcs.o \
+	daemon.o \
+	readline.o \
+	packets.o \
+	utils.o \
+	queue.o \
+	command.o \
+	dev.o \
+	dhcp.o \
+	command6.o \
+	packets6.o \
+	ip.o \
+	tcp.o \
+	inet6.o \
+	dns.o \
+	remote.o \
+	help.o \
+	dump.o \
+	relay.o \
+	hv.o \
+	frag.o \
+	frag6.o
+
+debug: all
+all: vpcs
+
+vpcs: $(OBJS)
+	$(CC) $(.ALLSRC) -o $(.TARGET) $(LDFLAGS)
+
+.c.o: vpcs.h packets.h dhcp.h
+	$(CC) $(INCLUDE_PATH) $(CFLAGS) -c $<
+
+clean:
+	$(RM) *.o vpcs
+
+.if make(debug)
+  DBGOPT=-DDEBUG -g
+.else
+  DBGOPT=-O2
+  STRIP=-s
+.endif

--- a/src/command.c
+++ b/src/command.c
@@ -1006,7 +1006,7 @@ int run_ipconfig(int argc, char **argv)
 		icidr = 24;
 
 	if (rip == -1 || gip == -1 || rip == gip ||
-#ifdef Linux
+#if (defined(Linux) || defined(OpenBSD))
 	    ((rip & 0x7f) == 0x7f) || rip == 0 || IN_MULTICAST(ntohl(rip))) {
 #else
 	    IN_LOOPBACK(ntohl(rip)) || IN_ZERONET(ntohl(rip)) || IN_MULTICAST(ntohl(rip))) {

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -55,6 +55,8 @@
 #include <pty.h>
 #elif FreeBSD
 #include <libutil.h>
+#elif OpenBSD
+#include <util.h>
 #endif
 
 #ifdef cygwin
@@ -139,7 +141,7 @@ daemonize(int port, int bg)
 	(void) setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
 	    (char *)&on, sizeof(on));
 
-	bzero((char *) &serv, sizeof(serv));
+	memset((char *) &serv, 0, sizeof(serv));
 	serv.sin_family = AF_INET;
 	serv.sin_addr.s_addr = htonl(INADDR_ANY);
 	serv.sin_port = htons(port);
@@ -171,7 +173,7 @@ pipe_rw(int fds, int fdd)
 	struct timeval tv;
 	int rc, len;
 	int n;
-	u_char buf[512];
+	unsigned char buf[512];
 	
 	tv.tv_sec = 0;
 	tv.tv_usec = 10 * 1000; 
@@ -331,7 +333,7 @@ set_telnet_mode(int s)
 	    "\xFF\xFB\x01"
 	    "\xFF\xFD\x03"
 	    "\xFF\xFB\x03";
-	u_char buf[512];
+	unsigned char buf[512];
 	int n;
 	
 	n = write(s, neg, strlen(neg));

--- a/src/dump.c
+++ b/src/dump.c
@@ -130,7 +130,7 @@ int dmp_packet(const struct packet *m, const int flag)
 
 static void dmp_arp(void *dat)
 {
-	arphdr *ah = (arphdr *)dat;	
+	vpcs_arphdr *ah = (vpcs_arphdr *)dat;
 	struct in_addr in;
 	u_char broadcast[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	u_int *si, *di;

--- a/src/hv.c
+++ b/src/hv.c
@@ -59,6 +59,9 @@
 #include <pty.h>
 #elif FreeBSD
 #include <libutil.h>
+#elif OpenBSD
+#include <termios.h>
+#include <util.h>
 #endif
 
 #ifdef cygwin
@@ -392,7 +395,7 @@ run_vpcs(int ac, char **av)
 	
 	/* reinitialized, maybe call getopt twice */
 	optind = 1;
-#if ((!defined(GNUkFreeBSD) && defined(FreeBSD)) || defined(Darwin))
+#if ((!defined(GNUkFreeBSD) && (defined(FreeBSD) || defined(OpenBSD))) || defined(Darwin))
 	optreset = 1;
 #endif	
 	while ((c = getopt(ac, av, "p:m:s:c:")) != -1) {

--- a/src/ip.h
+++ b/src/ip.h
@@ -51,7 +51,7 @@ typedef struct ethdr ethdr;
 #define ARPOP_REQUEST	1	/* request to resolve address */
 #define ARPOP_REPLY	2	/* response to previous request */
 
-struct  arphdr {
+struct  vpcs_arphdr {
 	u_short hrd;			/* format of hardware address */
 	u_short pro;			/* format of protocol address */
 	u_char  hln;			/* length of hardware address */
@@ -62,7 +62,7 @@ struct  arphdr {
 	u_char dea[ETH_ALEN];
 	u_char dip[4];
 };
-typedef struct arphdr arphdr;
+typedef struct vpcs_arphdr vpcs_arphdr;
 
 struct iphdr {
 	u_int   ihl:4,		/* ip header length, should be 20 bytes */

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -71,6 +71,9 @@ case ${os} in
     FreeBSD)
     	make -f Makefile.fbsd ${MKOPT}
     	;;
+    OpenBSD)
+	make -f Makefile.obsd ${MKOPT}
+	;;
     Linux)
         make -f Makefile.linux ${MKOPT}
         ;;

--- a/src/packets.c
+++ b/src/packets.c
@@ -175,7 +175,7 @@ int upv4(pcs *pc, struct packet **m0)
 		}	
 
 	} else if (eh->type == htons(ETHERTYPE_ARP)) {
-		arphdr *ah = (arphdr *)(eh + 1);
+		vpcs_arphdr *ah = (vpcs_arphdr *)(eh + 1);
 		si = (u_int *)ah->sip;
 		di = (u_int *)ah->dip;
 			
@@ -565,7 +565,7 @@ struct packet *packet(pcs *pc)
 struct packet *arp(pcs *pc, u_int dip)
 {
 	ethdr *eh;
-	arphdr *ah;
+	vpcs_arphdr *ah;
 	struct packet *m;
 	u_int *si, *di;
 	
@@ -574,7 +574,7 @@ struct packet *arp(pcs *pc, u_int dip)
 		return NULL;
 
 	eh = (ethdr *)(m->data);
-	ah = (arphdr *)(eh + 1);
+	ah = (vpcs_arphdr *)(eh + 1);
 
 	ah->hrd = htons(ARPHRD_ETHER);
 	ah->pro = htons(ETHERTYPE_IP);


### PR DESCRIPTION
This commit adds OpenBSD support, tested on OpenBSD-current in preparation for GNS3 port.

- New Makefile.obsd created
- bzero replaced with memset, because former is deprecated
- u_char replaced with unsigned char
- struct arphdr conflicts with OpenBSD's one, renamed to vpcs_arphdr

Tested with gns3-gui-2.2.37, gns3-server-2.2.37, ubridge-0.9.14 and dynamips-0.2.23
