### PR TITLE
Adjust the options in the DHCP REQUEST message

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -183,16 +183,18 @@ struct packet * dhcp4_request(pcs *pc, int stage)
 	dh->options[i++] = 1;
 	dh->options[i++] = DHCPREQUEST;
 	
-	dh->options[i++] = DHO_DHCP_SERVER_IDENTIFIER;
-	dh->options[i++] = 4;
-	((int*)(&dh->options[i]))[0] = pc->ip4.dhcp.svr;
-	i += sizeof(int);
-	
-	dh->options[i++] = DHO_DHCP_REQUESTED_ADDRESS;
-	dh->options[i++] = 4;
-	((int*)(&dh->options[i]))[0] = pc->ip4.dhcp.ip;
-	i += sizeof(int);
-	
+	if (stage == 0) {
+		dh->options[i++] = DHO_DHCP_SERVER_IDENTIFIER;
+		dh->options[i++] = 4;
+		((int*)(&dh->options[i]))[0] = pc->ip4.dhcp.svr;
+		i += sizeof(int);
+
+		dh->options[i++] = DHO_DHCP_REQUESTED_ADDRESS;
+		dh->options[i++] = 4;
+		((int*)(&dh->options[i]))[0] = pc->ip4.dhcp.ip;
+		i += sizeof(int);
+	}
+
 	dh->options[i++] = DHO_DHCP_CLIENT_IDENTIFIER;
 	dh->options[i++] = 7;
 	/* using hardware address as my identifier */


### PR DESCRIPTION
Modified the dhcp4_request function to properly construct DHCP REQUEST messages:

- In SELECTING state (stage 0): Include server identifier and requested IP address options
- In RENEWING state (stage 1): Exclude server identifier and requested IP address options
- In REBINDING state (stage 2): Exclude server identifier and requested IP address options

According to [RFC 2131 specifications](https://www.rfc-editor.org/rfc/rfc2131#page-32):

- DHCPREQUEST generated during RENEWING state:
  'server identifier' MUST NOT be filled in, 'requested IP address' option MUST NOT be filled in, 'ciaddr' MUST be filled in with client's IP address.
- DHCPREQUEST generated during REBINDING state:
  'server identifier' MUST NOT be filled in, 'requested IP address' option MUST NOT be filled in, 'ciaddr' MUST be filled in with client's IP address.